### PR TITLE
Support non16 dimens

### DIFF
--- a/mpeg.c
+++ b/mpeg.c
@@ -463,8 +463,8 @@ void mpeg_upload_frame(mpeg_player_t *player) {
     uint32_t *src = player->frame->display;
 
     /* Video size in macroblocks (16x16) */
-    const int video_blocks_w = player->frame->width  >> 4;
-    const int video_blocks_h = player->frame->height >> 4;
+    const int video_blocks_w = player->frame->y.width  >> 4;
+    const int video_blocks_h = player->frame->y.height >> 4;
 
     /*
      * PVR YUV converter stride (in macroblocks).

--- a/pl_mpeg.h
+++ b/pl_mpeg.h
@@ -3792,8 +3792,8 @@ void plm_video_predict_macroblock(plm_video_t *self) {
 void plm_video_copy_macroblock(
 	uint32_t *dest, plm_frame_t *reference, int motion_h, int motion_v
 ) {
-	int dw = reference->width;
-	int dh = reference->height;
+	int dw = reference->y.width;
+	int dh = reference->y.height;
 	int hp = motion_h < 0 ? (dw + (motion_h >> 1)) : (motion_h >> 1);
 	int vp = motion_v < 0 ? (dh + (motion_v >> 1)) : (motion_v >> 1);
 	int odd_h = (motion_h & 1) == 1;


### PR DESCRIPTION
Fix video corruption for non-multiple-of-16 dimensions
  MPEG-1 uses 16x16 macroblocks, so video dimensions are internally
  padded to the next multiple of 16. Two places incorrectly used the
  actual display dimensions instead of the padded plane dimensions:

  - pl_mpeg.h: plm_video_copy_macroblock() used reference->width/height
    as the stride when reading motion-predicted reference frame data.
    This caused every row to be offset incorrectly, corrupting P/B-frames.

  - mpeg.c: mpeg_upload_frame() computed the macroblock grid size via
    frame->width >> 4, which truncates (e.g. 318 >> 4 = 19 instead of
    20). This caused rows to desync during PVR YUV upload, scrambling
    the entire picture.

  Both now use the padded Y plane dimensions (frame->y.width/height),
  which are always correct multiples of 16.